### PR TITLE
Improve default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ The default configuration is as follows:
       :whitelist:
         - Fix
         - Add
+        - Change
         - Update
         - Remove
         - Refactor
+        - Enable
+        - Disable
     :commit_subject_suffix:
       :enabled: true
       :whitelist:
@@ -180,7 +183,7 @@ Here is an example workflow, using the gem defaults where errors would be raised
 
     d0f9bf40a09d10618bcf8a38a5ddd3bcf12fd550 (Brooke Kuhlmann, 3 seconds ago): This is a bogus commit message that is also terribly long and will word wrap
       Commit Subject Length: Invalid length. Use 72 characters or less.
-      Commit Subject Prefix: Invalid prefix. Use: "Fix", "Add", "Update", "Remove", "Refactor".
+      Commit Subject Prefix: Invalid prefix. Use: "Fix", "Add", "Change", "Update", "Remove", "Refactor", "Enable", "Disable".
       Commit Subject Suffix: Invalid suffix. Use: ".".
 
     3 issues detected.
@@ -351,10 +354,15 @@ imperative mode. The whitelist *is* case sensitive. The default whitelist consis
 following prefixes:
 
 - *Fix* - Existing code that has been fixed.
-- *Remove* - Code that was once added and is now removed.
 - *Add* - New code that is an enhancement, feature, etc.
+- *Change* - Something got changed.
 - *Update* - Existing code that has been modified.
+- *Remove* - Code that was once added and is now removed.
 - *Refactor* - Existing code that has been cleaned up and does not change functionality.
+- *Enable* - Enable a configuration option, such as a [Rubocop](https://github.com/bbatsov/rubocop)
+cop or a [HAML-Lint](https://github.com/brigade/haml-lint) linter.
+- *Disable* - Disable a configuration option, such as a [Rubocop](https://github.com/bbatsov/rubocop)
+cop or a [HAML-Lint](https://github.com/brigade/haml-lint) linter
 
 In practice, using a prefix other than what has been detailed above to explain *what* is being
 committed is never needed. This whitelist is not only short and easy to remember but also has the

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ The default configuration is as follows:
     :commit_subject_prefix:
       :enabled: true
       :whitelist:
-        - Fixed
-        - Added
-        - Updated
-        - Removed
-        - Refactored
+        - Fix
+        - Add
+        - Update
+        - Remove
+        - Refactor
     :commit_subject_suffix:
       :enabled: true
       :whitelist:
@@ -180,7 +180,7 @@ Here is an example workflow, using the gem defaults where errors would be raised
 
     d0f9bf40a09d10618bcf8a38a5ddd3bcf12fd550 (Brooke Kuhlmann, 3 seconds ago): This is a bogus commit message that is also terribly long and will word wrap
       Commit Subject Length: Invalid length. Use 72 characters or less.
-      Commit Subject Prefix: Invalid prefix. Use: "Fixed", "Added", "Updated", "Removed", "Refactored".
+      Commit Subject Prefix: Invalid prefix. Use: "Fix", "Add", "Update", "Remove", "Refactor".
       Commit Subject Suffix: Invalid suffix. Use: ".".
 
     3 issues detected.
@@ -346,14 +346,15 @@ word wrapped.
 |---------|------------------------|
 | true    | whitelist: (see below) |
 
-Ensures the commit subject uses consistent prefixes that help explain *what* is being commited. The
-whitelist *is* case sensitive. The default whitelist consists of the following prefixes:
+Ensures the commit subject uses consistent prefixes that help explain *what* is being commited in
+imperative mode. The whitelist *is* case sensitive. The default whitelist consists of the 
+following prefixes:
 
-- *Fixed* - Existing code that has been fixed.
-- *Removed* - Code that was once added and is now removed.
-- *Added* - New code that is an enhancement, feature, etc.
-- *Updated* - Existing code that has been modified.
-- *Refactored* - Existing code that has been cleaned up and does not change functionality.
+- *Fix* - Existing code that has been fixed.
+- *Remove* - Code that was once added and is now removed.
+- *Add* - New code that is an enhancement, feature, etc.
+- *Update* - Existing code that has been modified.
+- *Refactor* - Existing code that has been cleaned up and does not change functionality.
 
 In practice, using a prefix other than what has been detailed above to explain *what* is being
 committed is never needed. This whitelist is not only short and easy to remember but also has the

--- a/lib/git/cop/styles/commit_subject_prefix.rb
+++ b/lib/git/cop/styles/commit_subject_prefix.rb
@@ -7,7 +7,7 @@ module Git
         def self.defaults
           {
             enabled: true,
-            whitelist: %w[Fixed Added Updated Removed Refactored]
+            whitelist: %w[Fix Add Update Remove Refactor]
           }
         end
 

--- a/lib/git/cop/styles/commit_subject_prefix.rb
+++ b/lib/git/cop/styles/commit_subject_prefix.rb
@@ -7,7 +7,7 @@ module Git
         def self.defaults
           {
             enabled: true,
-            whitelist: %w[Fix Add Update Remove Refactor]
+            whitelist: %w[Fix Add Change Update Remove Refactor Enable Disable]
           }
         end
 

--- a/ruby
+++ b/ruby
@@ -1,0 +1,1 @@
+ruby.ruby2.4

--- a/spec/lib/git/cop/runner_spec.rb
+++ b/spec/lib/git/cop/runner_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Git::Cop::Runner, :temp_dir, :git_repo do
     {
       commit_body_leading_space: {enabled: true},
       commit_subject_length: {enabled: true, length: 50},
-      commit_subject_prefix: {enabled: true, whitelist: %w[Fixed Added Updated Removed Refactored]},
+      commit_subject_prefix: {enabled: true, whitelist: %w[Fix Add Update Remove Refactor]},
       commit_subject_suffix: {enabled: true, whitelist: ["."]}
     }
   end

--- a/spec/lib/git/cop/runner_spec.rb
+++ b/spec/lib/git/cop/runner_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Git::Cop::Runner, :temp_dir, :git_repo do
     {
       commit_body_leading_space: {enabled: true},
       commit_subject_length: {enabled: true, length: 50},
-      commit_subject_prefix: {enabled: true, whitelist: %w[Fix Add Update Remove Refactor]},
+      commit_subject_prefix: {enabled: true, whitelist: %w[Fix Add Change Update Remove Refactor Enable Disable]},
       commit_subject_suffix: {enabled: true, whitelist: ["."]}
     }
   end

--- a/spec/lib/git/cop/styles/commit_subject_prefix_spec.rb
+++ b/spec/lib/git/cop/styles/commit_subject_prefix_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Git::Cop::Styles::CommitSubjectPrefix do
   let(:content) { "Added test subject." }
   let(:commit) { object_double Git::Cop::Commit.new(sha: "1"), subject: content }
-  let(:settings) { {enabled: true, whitelist: %w[Added Removed Fixed]} }
+  let(:settings) { {enabled: true, whitelist: %w[Add Remove Fix]} }
   subject { described_class.new commit: commit, settings: settings }
 
   describe ".id" do
@@ -55,7 +55,7 @@ RSpec.describe Git::Cop::Styles::CommitSubjectPrefix do
       let(:content) { "Bogus subject line." }
 
       it "answers error message" do
-        expect(subject.error).to eq(%(Invalid prefix. Use: "Added", "Removed", "Fixed".))
+        expect(subject.error).to eq(%(Invalid prefix. Use: "Add", "Remove", "Fix".))
       end
     end
   end


### PR DESCRIPTION
Commit message should be in imperative mode, as it is explained for example in [Github Write good commit messages guide](https://github.com/erlang/otp/wiki/Writing-good-commit-messages#do).

This guide also includes the `Change` prefix for the commit message. So I guess it should also be here. :wink: 

`Enable` and `Disable` prefix are very useful for example when enabling/disabling style rules in [Rubocop](https://github.com/bbatsov/rubocop) or [HAML-Lint.](https://github.com/brigade/haml-lint)