### PR TITLE
Added Travis support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,13 +198,12 @@ variable. Most CI build servers respect and enable this variable. If your CI ser
 want to make sure you have `CI=true` set in your environment.
 
 Calculation of commits is done by reviewing all commits made on the current feature branch since
-branching from `master`. Some CI servers don't respect this and blow away any branch information,
-most notibly, Travis CI. For that reason, Travis CI is not supported or recommended as they use
-`git clone --depth=<number>` cloning which can't be customized and destroys any knowledge of
-`master` and feature branch information.
+branching from `master`. Some CI servers don't respect this and blow away any branch information.
 
 Build servers like [Circle CI](https://circleci.com) are recommended. The builds for this gem are
 done via Circle CI as well.
+
+Travis CI is also supported.
 
 ## Cops
 

--- a/lib/git/cop/branch.rb
+++ b/lib/git/cop/branch.rb
@@ -10,10 +10,16 @@ module Git
       end
 
       def name
+        if ENV["TRAVIS"] == "true"
+          pr_branch = ENV["TRAVIS_PULL_REQUEST_BRANCH"]
+          return pr_branch unless pr_branch.empty?
+          return ENV["TRAVIS_BRANCH"]
+        end
         "#{path}#{`git rev-parse --abbrev-ref HEAD | tr -d '\n'`}"
       end
 
       def shas
+        set_travis if ENV["TRAVIS"] == "true"
         `git log --pretty=format:"%H" #{master}..#{name}`.split("\n")
       end
 
@@ -23,6 +29,18 @@ module Git
 
       def master
         "#{path}master"
+      end
+
+      def set_travis
+        pr_slug = ENV["TRAVIS_PULL_REQUEST_SLUG"]
+        unless pr_slug.empty?
+          # origin is set to the upstream in a PR in Travis
+          `git remote add original_branch https://github.com/#{pr_slug}.git`
+          `git fetch original_branch #{name}:#{name}`
+        end
+        # Travis doesn't know master by default
+        `git remote set-branches --add origin master`
+        `git fetch`
       end
     end
   end


### PR DESCRIPTION
Know git-cop works in Travis. :tada: 

We need to consider the case of a PR and a branch separately. Two working examples:

https://travis-ci.org/Ana06/open-build-service/jobs/250334265
https://travis-ci.org/openSUSE/open-build-service/jobs/250334288

The main problem is that Travis only "load" the local branch, so it doesn't know things likes `origin/master`. Also in a PR, Travis call the branch master so we need to find the correct branch.

There are some problems with Travis environment variables. Seems that some of then are wrong and doesn't much the documentation. If this is fixed, this could even be written before. I'll open an issue in Travis, but this is actually not important for as, because we can use git-cop in Travis already.

There is only one case when this doesn't work and is if you run git-cop rspec test on Travis (example: https://travis-ci.org/Ana06/git-cop/builds/250767034). But as Circle CI is used this shouldn't be a problem.

Fixes https://github.com/bkuhlmann/git-cop/issues/12
