### PR TITLE
Fixed Travis.

### DIFF
--- a/lib/git/cop/branches/environments/travis_ci.rb
+++ b/lib/git/cop/branches/environments/travis_ci.rb
@@ -47,6 +47,7 @@ module Git
 
             unless slug.empty?
               shell.capture2e "git remote add -f original_branch https://github.com/#{slug}.git"
+              shell.capture2e "git fetch original_branch #{name}:#{name}"
             end
 
             shell.capture2e "git remote set-branches --add origin master"

--- a/spec/lib/git/cop/branches/environments/travis_ci_spec.rb
+++ b/spec/lib/git/cop/branches/environments/travis_ci_spec.rb
@@ -63,10 +63,12 @@ RSpec.describe Git::Cop::Branches::Environments::TravisCI do
     end
 
     it "answers Git commit SHAs with pull request slug" do
-      remote_command = "git remote add -f original_branch https://github.com/test_slug.git"
+      remote_add_command = "git remote add -f original_branch https://github.com/test_slug.git"
+      remote_fetch_command = "git fetch original_branch test_name:test_name"
 
       allow(described_class).to receive(:pull_request_slug).and_return("test_slug")
-      allow(shell).to receive(:capture2e).with(remote_command)
+      allow(shell).to receive(:capture2e).with(remote_add_command)
+      allow(shell).to receive(:capture2e).with(remote_fetch_command)
 
       expect(subject.shas).to contain_exactly("abc", "def")
     end


### PR DESCRIPTION
The code to support Travis from https://github.com/bkuhlmann/git-cop/pull/16 was refactored in https://github.com/bkuhlmann/git-cop/pull/20. The refactored code broke the Travis support for PRs and it is only working in local branches, as it was missing one important line that is used in the case of PRs.

Fixes bkuhlmann#24