### PR TITLE
Fixed typo in default configuration of README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ The default configuration is:
       :enabled: true
       :severity: :error
       :blacklist:
-      basically
         - basically
         - "\\beasy\\b"
         - everyone knows


### PR DESCRIPTION
Fixed error message:

Invalid configuration (/home/user/.config/git-cop/configuration.yml): could not find expected ':' while scanning a simple key at line 46 column 3.
